### PR TITLE
Substitute digitalRead

### DIFF
--- a/ext/lgpio/extconf.rb
+++ b/ext/lgpio/extconf.rb
@@ -6,4 +6,6 @@ require 'mkmf'
 #
 $libs += " -llgpio"
 
+$CFLAGS += " -Werror=implicit-function-declaration"
+
 create_makefile('lgpio/lgpio')

--- a/ext/lgpio/lgpio.c
+++ b/ext/lgpio/lgpio.c
@@ -618,7 +618,7 @@ static VALUE one_wire_reset(VALUE self, VALUE rbHandle, VALUE rbGPIO) {
   clock_gettime(CLOCK_MONOTONIC, &start);
   now = start;
   while(nanoDiff(&now, &start) < 250000){
-    if (digitalRead(gpio) == 0) presence = 0;
+    if (lgGpioRead(handle, gpio) == 0) presence = 0;
     clock_gettime(CLOCK_MONOTONIC, &now);
   }
 


### PR DESCRIPTION
Hi,
first, thanks for all that denko-rb stuff. I use this extensively in rails applications on Raspberry Pis with NixOS.

After removing the Arduino stuff from my computer, I discovered an issue. It started with an "implicit function declaration error" while installing the gem, which I could "fix" with setting ```BUNDLE_BUILD__LGPIO="--with-cflags=-Wno-implicit-function-declaration"``` env variable. But I coundn't start the rails console any more.
```
bsh ❯ be rails c
/path/to/project/.devenv/state/.bundle/ruby/3.4.0/gems/lgpio-0.1.12/lib/lgpio.rb:1:in 'Kernel#require_relative': /path/to/project/.devenv/state/.bundle/ruby/3.4.0/gems/lgpio-0.1.12/lib/lgpio/lgpio.so: undefined symbol: digitalRead - /path/to/project/.devenv/state/.bundle/ruby/3.4.0/gems/lgpio-0.1.12/lib/lgpio/lgpio.so (LoadError)
...
```
This PR is a wild guess, since don't know much C. It's based on the assumption, that digitalRead is an Arduino related function, which sneaked into this code by accident. All I can say is, this fixes the issue for me and now the gem works as expected again.